### PR TITLE
added second userRemoteConfigs to jenkins file

### DIFF
--- a/jenkins/JenkinsfileUnified.build
+++ b/jenkins/JenkinsfileUnified.build
@@ -29,6 +29,7 @@ pipeline {
                           gitTool: 'Default',
                           submoduleCfg: [],
                           userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/gages-through-the-ages']]
+                          userRemoteConfigs: [[url: 'https://github.com/usgs-makerspace/gages-through-the-ages'.git]]
                         ])
                 }
         }


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Added second userRemoteConfig
-----------
I have no idea why this would stop the auto building, but I have seen this in other projects that work, so giving it a try

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial