### PR TITLE
removing some existing google analytics tracking as test

### DIFF
--- a/src/assets/references/references.js
+++ b/src/assets/references/references.js
@@ -1,8 +1,7 @@
 // Use this template for adding additional references.
 // {
 //     reference: "",
-//          href: "",
-//         googleAnalytics: "$ga.commands.trackName.bind(this, 'click-reference', 'click', 'user went to reference ')",
+//          href: ""
 // }
 
 export default {
@@ -11,13 +10,11 @@ export default {
         references: [
             {
                 reference: "Sample reference one",
-                href: "",
-                googleAnalytics: "$ga.commands.trackName.bind(this, 'click-reference', 'click', 'user went to reference')",
+                href: ""
             },
             {
                 reference: "Sample reference two",
-                href: "",
-                googleAnalytics: "$ga.commands.trackName.bind(this, 'click-reference', 'click', 'user went to reference')",
+                href: ""
             },
 
         ]

--- a/src/components/FooterLinks.vue
+++ b/src/components/FooterLinks.vue
@@ -4,7 +4,6 @@
       <p>Other visualizations of interest</p>
       <div class="footer-viz-links">
         <a
-          v-ga="$ga.commands.trackName.bind(this, 'link - hurricane maria', 'click', 'user selected prefooter visualization link')"
           :href="mariaLink"
         >
           <figcaption>Hurricane Maria's Water Footprint</figcaption>
@@ -14,7 +13,6 @@
           >
         </a>
         <a
-          v-ga="$ga.commands.trackName.bind(this, 'link - water use', 'click', 'user selected prefooter visualization link')"
           :href="waterUseLink"
         >
           <figcaption>Water use in the U.S., 2015</figcaption>

--- a/src/views/Error404.vue
+++ b/src/views/Error404.vue
@@ -19,7 +19,6 @@
     </p>
     <router-link to="/">
       <button
-        v-ga="$ga.commands.trackName.bind(this, 'Button - 404', 'click', 'user went from error page to index')"
         class="usa-button--inverse"
       >
         {{ title }} main page


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [ ] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Test of Google Tag Manager
-----------
I removed some of the existing Google Analytics tracking as a test to see if the new Google Tab Manager settings will pick them up

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial
