### PR TITLE
Possible resize hack

### DIFF
--- a/src/components/MapboxSlider.vue
+++ b/src/components/MapboxSlider.vue
@@ -154,6 +154,13 @@ export default {
                 maxZoom: 9,
                 interactive: this.interactive
             });
+            //Makes sure the bounds are being honored, hopefully for IOS
+            window.addEventListener('resize', function(){
+              georgiaAfterMap.fitBounds(georgiaBounds);
+              georgiaBeforeMap.fitBounds(georgiaBounds);
+              coloradoAfterMap.fitBounds(coloradoBounds);
+              coloradoBeforeMap.fitBounds(coloradoBounds);
+            })
             //Add Urban Extents
             this.AddUrbanExtent(coloradoBeforeMap, urban1970Extent, 'co1970Extent', 'combined_urban_areas_1970');
             this.AddUrbanExtent(coloradoAfterMap, urban2018Extent, 'co2018Extent', 'combined_urban_areas_2018');


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
This stops the map from getting out of whack visually when resizing the window manually.  Hoping this might fix the IOS size issue, but if not this might just get pulled out...will think about the advantages to cons.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
