### PR TITLE
Stop map objects from moving

### DIFF
--- a/src/components/MapboxSlider.vue
+++ b/src/components/MapboxSlider.vue
@@ -263,6 +263,7 @@ export default {
           let div = document.createElement('div');
           div.className = 'yearDiv ' +  divId + '';
           div.innerHTML = year;
+          div.draggable = false;
           canvas.appendChild(div);
         },
         addScales(map){
@@ -336,6 +337,11 @@ $ScaleColor: rgb(120,120,120);
     margin: 10px 0 0 10px;
     padding: 5px 0;
     text-align: center;
+    -webkit-user-select: none; /* Safari, Chrome */
+    -khtml-user-select: none; /* Konqueror */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE */
+    user-select: none; /* CSS3 */
     &::selection{
       color: none;
       background: none;

--- a/src/components/coloradoInsetMap.vue
+++ b/src/components/coloradoInsetMap.vue
@@ -4,6 +4,7 @@
       src="~@/images/inset/insetColoradoSmall.png"
       srcset="~@/images/inset/insetColoradoSmall.png 199w, ~@/images/inset/insetColoradoMedium.png 397w, ~@/images/inset/insetColoradoLarge.png 794w"
       alt="United States Lower 48 Highlighting Colorado"
+      draggable="false"
     >
   </div>
 </template>
@@ -21,9 +22,19 @@ export default {
         bottom: 10px;
         z-index: 90000;
         object-fit: 'contain'; 
+        -webkit-user-select: none; /* Safari, Chrome */
+        -khtml-user-select: none; /* Konqueror */
+        -moz-user-select: none; /* Firefox */
+        -ms-user-select: none; /* IE */
+        user-select: none; /* CSS3 */
         img{
             width: 100%;
             height: 100%;
+            -webkit-user-select: none; /* Safari, Chrome */
+            -khtml-user-select: none; /* Konqueror */
+            -moz-user-select: none; /* Firefox */
+            -ms-user-select: none; /* IE */
+            user-select: none; /* CSS3 */
         }
     }
 </style>

--- a/src/components/coloradoInsetMap.vue
+++ b/src/components/coloradoInsetMap.vue
@@ -23,11 +23,6 @@ export default {
         bottom: 10px;
         z-index: 90000;
         object-fit: 'contain'; 
-        -webkit-user-select: none; /* Safari, Chrome */
-        -khtml-user-select: none; /* Konqueror */
-        -moz-user-select: none; /* Firefox */
-        -ms-user-select: none; /* IE */
-        user-select: none; /* CSS3 */
         img{
             width: 100%;
             height: 100%;

--- a/src/components/coloradoInsetMap.vue
+++ b/src/components/coloradoInsetMap.vue
@@ -5,6 +5,7 @@
       srcset="~@/images/inset/insetColoradoSmall.png 199w, ~@/images/inset/insetColoradoMedium.png 397w, ~@/images/inset/insetColoradoLarge.png 794w"
       alt="United States Lower 48 Highlighting Colorado"
       draggable="false"
+      ondragstart="return false;"
     >
   </div>
 </template>

--- a/src/components/georgiaInsetMap.vue
+++ b/src/components/georgiaInsetMap.vue
@@ -4,6 +4,7 @@
       src="~@/images/inset/insetGeorgiaSmall.png"
       srcset="~@/images/inset/insetGeorgiaSmall.png 200w, ~@/images/inset/insetGeorgiaMedium.png 402w, ~@/images/inset/insetGeorgiaLarge.png 804w"
       alt="The state of Georgia Highlighting the City of Atlanta"
+      draggable="false"
     >
   </div>
 </template>
@@ -24,6 +25,11 @@ export default {
         img{
           width: 100%;
           height: 100%;
+          -webkit-user-select: none; /* Safari, Chrome */
+          -khtml-user-select: none; /* Konqueror */
+          -moz-user-select: none; /* Firefox */
+          -ms-user-select: none; /* IE */
+          user-select: none; /* CSS3 */
         }
     }
 </style>

--- a/src/components/georgiaInsetMap.vue
+++ b/src/components/georgiaInsetMap.vue
@@ -5,6 +5,7 @@
       srcset="~@/images/inset/insetGeorgiaSmall.png 200w, ~@/images/inset/insetGeorgiaMedium.png 402w, ~@/images/inset/insetGeorgiaLarge.png 804w"
       alt="The state of Georgia Highlighting the City of Atlanta"
       draggable="false"
+      ondragstart="return false;"
     >
   </div>
 </template>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Title
-----------
Brief description of changes. Reference the JIRA ticket if appropriate

Description
-----------
Number should stay put. Or they better!
The inset images shouldn't move now either. 

No movement besides the compare bar.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
