### PR TITLE
changes to control order of component loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
           "affiliation": { "@context": "http://schema.org",
             "@type": "Organization", "legalName": "U.S. Geological Survey" }
         },
-        { "@type": "Person", "name": "Linsay Platt",
+        { "@type": "Person", "name": "Lindsay Platt",
           "email": "lplatt@usgs.gov",
           "affiliation": { "@type": "Organization", "legalName": "U.S. Geological Survey" }
         },

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,8 +4,8 @@
     <HeaderUSGS />
     <WorkInProgressWarning />
     <router-view :is-internet-explorer="isInternetExplorer" />
-    <FooterLinks />
-    <FooterUSGS />
+    <FooterLinks v-if="checkIfBarChartIsRendered" />
+    <FooterUSGS v-if="checkIfBarChartIsRendered" />
   </div>
 </template>
 
@@ -13,9 +13,6 @@
     import HeaderUSWDSBanner from './components/HeaderUSWDSBanner'
     import HeaderUSGS from './components/HeaderUSGS'
     import WorkInProgressWarning from "./components/WorkInProgressWarning"
-    import FooterLinks from './components/FooterLinks'
-    import FooterUSGS from './components/FooterUSGS'
-
 
     export default {
         name: 'App',
@@ -23,12 +20,17 @@
             HeaderUSWDSBanner,
             HeaderUSGS,
             WorkInProgressWarning,
-            FooterLinks,
-            FooterUSGS
+            FooterLinks: () => import( /* webpackPrefetch: true */ /*webpackChunkName: "pre-footer-links"*/ "./components/FooterLinks"),
+            FooterUSGS: () => import( /* webpackPrefetch: true */ /*webpackChunkName: "usgs-footer"*/ "./components/FooterUSGS")
         },
         data() {
             return {
                 isInternetExplorer: false,
+            }
+        },
+        computed: {
+            checkIfBarChartIsRendered() {
+                return this.$store.state.svgRenderedOnInitialLoad;
             }
         },
         created() {

--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -2715,7 +2715,11 @@
         mounted() {
           this.setUpHoverText();
           this.startMonitoringLocationAnimation();
-
+          // The following code will only run after the entire view GagesBarChartAnimation has been rendered
+          // it will change the Vuex state so that other components will know the the GagesBarChartAnimation map has loaded
+          this.$nextTick(function () {
+              this.$store.commit('changeBooleanStateOnSVGMapRender');
+          });
         },
         methods: {
             runGoogleAnalytics(eventName, action, label) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -5,6 +5,12 @@ Vue.use(Vuex);
 
 export const store = new Vuex.Store({
     state: {
+        svgRenderedOnInitialLoad: false
 
+    },
+    mutations: {
+        changeBooleanStateOnSVGMapRender (state) {
+            state.svgRenderedOnInitialLoad = true
+        }
     }
 });

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,32 +1,30 @@
 <template>
   <div id="Visualization">
     <GagesBarChartAnimation />
-    <MapboxSlider />
-    <AnnotatedTimeline />
-    <TakeAway />
-    <DataSources />
-    <Methods />
-    <References />
+    <MapboxSlider v-if="checkIfBarChartIsRendered" />
+    <AnnotatedTimeline v-if="checkIfBarChartIsRendered" />
+    <TakeAway v-if="checkIfBarChartIsRendered" />
+    <DataSources v-if="checkIfBarChartIsRendered" />
+    <Methods v-if="checkIfBarChartIsRendered" />
+    <References v-if="checkIfBarChartIsRendered" />
   </div>
 </template>
 <script>
-  // import GagesBarChartAnimation from "../components/GagesBarChartAnimation";
-  // import MapboxSlider from "../components/MapboxSlider";
-  // import AnnotatedTimeline from "../components/AnnotatedTimeline";
-  import TakeAway from '../components/TakeAway';
-  import DataSources from "../components/DataSources";
-  import Methods from "../components/Methods";
-  import References from '../components/References';
   export default {
       name: 'Visualization',
       components: {
           GagesBarChartAnimation: () => import( /* webpackPrefetch: true */ /*webpackChunkName: "SVG-Animation"*/ "../components/GagesBarChartAnimation"),
           MapboxSlider: () => import(/*webpackChunkName: "mapbox-slider"*/ "../components/MapboxSlider"),
           AnnotatedTimeline: () => import(/*webpackChunkName: "annotated-barchart"*/ "../components/AnnotatedTimeline"),
-          TakeAway,
-          DataSources,
-          Methods,
-          References
+          TakeAway: () => import(/*webpackChunkName: "take-away"*/ "../components/TakeAway"),
+          DataSources: () => import(/*webpackChunkName: "data-sources"*/ "../components/DataSources"),
+          Methods: () => import(/*webpackChunkName: "methods"*/ "../components/Methods"),
+          References: () => import(/*webpackChunkName: "references"*/ "../components/References")
+      },
+      computed: {
+           checkIfBarChartIsRendered() {
+               return this.$store.state.svgRenderedOnInitialLoad;
+           }
       }
   }
 </script>


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Make the Main SVG Map load first
-----------
This uses a combination of the Vuex store, computed properties, selective Webpack chunking, and conditional component loading, so that the Main SVG is given first load priority and prevents any of the other components from loading until that happens.  


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
