### PR TITLE
fix for methods menus

### DIFF
--- a/src/components/Methods.vue
+++ b/src/components/Methods.vue
@@ -66,7 +66,6 @@ $chevronDown: '~@/assets/images/chevron-down.png';
   button:not([disabled]):focus{
     outline: none;
   }
-
   .usa-accordion__button{
     background-image: url($chevronDown);
     background-size: 15px 10px;

--- a/src/components/Methods.vue
+++ b/src/components/Methods.vue
@@ -21,7 +21,7 @@
         </h2>
         <div
           :id="method.title"
-          class="usa-accordion__content usa-prose"
+          class="usa-accordion__content usa-prose gage-target"
         >
           <p><span v-html="method.method" /></p>
         </div>
@@ -37,6 +37,13 @@
             return{
                 methods: methods.methodContent
             }
+        },
+        mounted() {
+            // This is a fix for the weird USWDS glitch that causes the Methods section accordion menus to be open on page load
+            const targetAccordionDivs = document.querySelectorAll('div.gage-target');
+            targetAccordionDivs.forEach((div) => {
+                div.setAttribute('hidden', '""');
+            });
         },
         methods: {
             runGoogleAnalytics(eventName, action, label) {
@@ -59,6 +66,7 @@ $chevronDown: '~@/assets/images/chevron-down.png';
   button:not([disabled]):focus{
     outline: none;
   }
+
   .usa-accordion__button{
     background-image: url($chevronDown);
     background-size: 15px 10px;


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [x] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Fix Open Methods Menus
-----------
This sets the Methods menus to closed on page load, which was an odd bug created when the components were lazy loaded. Perhaps there is a timing in the USWDS code that closes the menus when in a standard load pattern. But the lazy load, seems to mess with that, so this closes the menus once the component is mounted (rendered)

After making a pull request
---------------------------
- [] If appropriate, put the link to the PR in the ticket
- [x] Assign someone to review unless the change is trivial
