### PR TITLE
added fix for official banner that opens and closes during load

### DIFF
--- a/src/components/HeaderUSWDSBanner.vue
+++ b/src/components/HeaderUSWDSBanner.vue
@@ -82,9 +82,13 @@ import iconHTTPS from '../../node_modules/uswds/dist/img/icon-https.svg';
         components: {
           iconDot,
           iconHTTPS
+        },
+        mounted() {
+            // This is a fix for the weird USWDS glitch that causes the official united states banner pop and then close as the page loads
+            const bannerElement = document.querySelector('#gov-banner');
+            bannerElement.setAttribute('hidden', '""');
         }
     }
-
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [ ] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [ ] Chrome
- [] Safari
- [ ] Edge
- [x] Firefox
- [ ] Samsung Internet
- [ ] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Fix the Annoying USWSD Banner that Pops Open and then Closes on Loads
-----------
This issue is related to the reason the USWDS accordions like to pop open when they should be closed. This applies a similar fix that just adds and sets the attribute 'hidden' to an empty string. This allow the USWDS component to function as expected during and after load.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial
