### PR TITLE
slightly hacky tooltip fxn

### DIFF
--- a/data_processing_pipeline/6_visualize.yml
+++ b/data_processing_pipeline/6_visualize.yml
@@ -6,11 +6,13 @@ packages:
   
 sources:
   - 6_visualize/src/build_svg.R
+  - 6_visualize/src/add_tooltip.R
 
 targets:
   6_visualize:
     depends:
       - 6_visualize/out/cartogram_init.svg
+      - 6_visualize/out/cartogram_init_tooltip.svg
   
   start_yr:
     command: viz_year_range[[1]]
@@ -43,3 +45,6 @@ targets:
       start_yr = start_yr,
       end_yr = end_yr)
   
+  6_visualize/out/cartogram_init_tooltip.svg:
+    command: add_tooltip_to_xml(
+      target_name, "6_visualize/out/cartogram_init.svg")

--- a/data_processing_pipeline/6_visualize/src/add_tooltip.R
+++ b/data_processing_pipeline/6_visualize/src/add_tooltip.R
@@ -1,0 +1,31 @@
+insert_tooltip <- function(xml_doc) {
+  
+  # Find location of last bar group start, then add 2 to get to the closing </g>
+  last_bar <- tail(grep("-bars", xml_doc), 1) + 2
+  
+  # Now find start of first hover (should be last_bar + 1)
+  first_hover <- head(grep("-hovers", xml_doc), 1)
+  
+  # Now reconstruct to fit this tool tip code in between those
+  tooltip <- c(
+    '<rect id="tooltip_bg" height="32" class="hidden"/>',
+    ' <g id="tool_pt" class="hidden">',
+    '  <defs>',
+    '   <clipPath id="tip-clip">',
+    '    <rect x="-8" width="16" y="-9.5" height="11"/>',
+    '   </clipPath>',
+    '  </defs>',
+    ' <path d="M-6,-10 l6,10 l6,-10" class="tooltip-box" clip-path="url(#tip-clip)"/>',
+    ' </g>',
+    '<text id="tooltip" stroke="none" dy="-15" fill="#000000" text-anchor="middle" class="sub-label"> </text>'
+  )
+  
+  c(head(xml_doc, last_bar), tooltip, xml_doc[first_hover:length(xml_doc)])
+  
+}
+
+add_tooltip_to_xml <- function(target_name, xml_file) {
+  readLines(xml_file) %>% 
+    insert_tooltip() %>% 
+    writeLines(target_name)
+}


### PR DESCRIPTION
This adds the tooltip nodes but relies on the CSS and Javascript functions for showing and styling the tooltip to exist in Vue in order to work. You will need to use the `6_visualize/out/cartogram_init_tooltip.svg` SVG file to get the tooltip.

"slightly hacky" because we aren't totally satisfied with this but we want to test out whether it functions correctly on test.