### PR TITLE
Cartogram hover fixes, pt 1: no hover on mobile & fix lingering hovers

### DIFF
--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -2017,7 +2017,7 @@ $polygon: '~@/assets/images/polygon.png';
 }
 }
 .hidden {
-  opacity:.2;
+  opacity: 0;
 }
 .tooltip-box{
   stroke-width: 0.5;

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -2035,4 +2035,16 @@ $polygon: '~@/assets/images/polygon.png';
         font-size: 1.5em;
     }
 }
+/*Touch screen devices - no hover*/
+@media screen and (hover: none) and (pointer: coarse) {
+  #cartogram-svg{
+    pointer-events: none;
+  }
+  #annotate-svg{
+    display: none;
+  }
+  #arrow.annotate{
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
This fixes 2/3 of hover related issues we discussed this morning - disabling hovers on touch screen devices and making hovers on the cartogram disappear completely when you are no longer hovering. I'm no CSS whiz, so I hope this is good 😃 