### PR TITLE
Firefox fix for hovers & make instructions disappear after hovering

### DIFF
--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -1847,7 +1847,8 @@
           return{
               atlantaText: atlantaSliderText.textContents,
               svg: null,
-              pt: null
+              pt: null,
+              firstHover: null
           }
       },
       mounted(){
@@ -1866,6 +1867,12 @@
         },
         
         gagetip(evt) {
+      
+          if (!this.firstHover) {
+            document.getElementById("annotate-svg").setAttribute("class","hidden");
+            document.getElementById("arrow").setAttribute("class","hidden");
+            this.firstHover = true;
+          }
       
           let tooltip = document.getElementById("tooltip");
           let tooltip_bg = document.getElementById("tooltip_bg");

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -1884,12 +1884,12 @@
             let svgWidth = Number(this.svg.getAttribute("viewBox").split(" ")[2]);
             tooltip.setAttribute("x",this.pt.x);
             tooltip.setAttribute("y",this.pt.y);
-      
-            let translate_elements = window.getComputedStyle(evt.target.parentElement).transform;
-            let scale_elements = window.getComputedStyle(evt.target).transform;
-      
-            let scaleX = scale_elements.split(", ")[0].split("matrix(")[1];
-            let translateX = translate_elements.split(", ")[4];
+            
+            let translate_elements = evt.target.parentElement.getAttribute("transform");
+            let scale_elements = evt.target.getAttribute("transform");
+            
+            let scaleX = scale_elements.split(/scale\(| /)[1];
+            let translateX = translate_elements.split(/translate\(| /)[1];
             let tip_JSON = evt.target.getAttribute("data");
             let tip_data = JSON.parse(tip_JSON);
             let pt_index = Math.round((this.pt.x - Math.round(translateX) ) / scaleX - 0.5);


### PR DESCRIPTION
This does two things:

1. Fixes the issue where Firefox tooltips weren't able to get the gage counts and year from the mouse event. 
2. Adds functionality where the cartogram hover instructions & arrow disappear after someone hovers and gets a tooltip for the first time.

I checked Chrome, Firefox, and Edge to ensure that these changes work.