### PR TITLE
adjust whitespace and font

### DIFF
--- a/data_processing_pipeline/6_visualize/src/build_svg.R
+++ b/data_processing_pipeline/6_visualize/src/build_svg.R
@@ -155,7 +155,7 @@ add_title <- function(svg_root) {
     xml_add_child("text", id = "title-svg", transform = "translate(0 0)",
                   style = "font-size: 10px; font-style: italic; fill: rgb(139, 139, 139);",
                   "State-level trends in USGS streamgaging") %>% 
-    xml_add_child("tspan", x=0, y=15, "1890 - present")
+    xml_add_child("tspan", x=0, y=15, "from 1890 to present")
   
 }
 

--- a/data_processing_pipeline/6_visualize/src/build_svg.R
+++ b/data_processing_pipeline/6_visualize/src/build_svg.R
@@ -153,7 +153,7 @@ add_title <- function(svg_root) {
   
   svg_root %>% 
     xml_add_child("text", id = "title-svg", transform = "translate(0 0)",
-                  style = "font-size: 14px; font-weight: 600; fill: rgb(139, 139, 139);",
+                  style = "font-size: 10px; font-style: italic; fill: rgb(139, 139, 139);",
                   "State-level trends in USGS streamgaging") %>% 
     xml_add_child("tspan", x=0, y=15, "1890 - present")
   

--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -2694,6 +2694,7 @@
         aria-hidden="true"
       >
         <g class="cls-1">
+          <g id="bottom" transform="translate(0, -120)">
           <g id="end-water-background">
             <path
               class="cls-2"
@@ -2862,6 +2863,7 @@
               </tspan>
             </text>
           </g>
+          </g>
           <g id="funding-text">
             <text
               class="cls-16"
@@ -2885,6 +2887,7 @@
               x="14.4"
               y="28.8"
             >local partner agencies.</tspan></tspan></text>
+            <g id="mgmt-text" transform="translate(0, -40)">
             <text
               class="cls-16"
               transform="translate(202 1864.5)"
@@ -2899,6 +2902,7 @@
               x="0"
               y="28.8"
             >which has been operating gages for the last 130 years.</tspan></text>
+          </g>
           </g>
           <g id="funding-partner-agencies">
             <g>

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -1774,7 +1774,7 @@
         >State-level trends in USGS streamgaging<tspan
           x="0"
           y="10"
-        >1890 - present</tspan></text>
+        >from 1890 to present</tspan></text>
         <text
           id="annotate-svg"
           transform="translate(175 325)"
@@ -2009,12 +2009,6 @@ $polygon: '~@/assets/images/polygon.png';
 #cartogram-svg {
   width:150%;
   height: auto;
-
-  #title-svg {
-    fill: rgb(139, 139, 139);
-    font-style: italic;
-    font-size: 10px;
-  }
 
 .state-label{
   font-size: 8px;

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -1770,10 +1770,10 @@
         <text
           id="title-svg"
           transform="translate(0 0)"
-          style="font-size: 14px; font-weight: 600; fill: rgb(139, 139, 139);"
+          style="font-size: 10px; font-style: italic; fill: rgb(139, 139, 139);"
         >State-level trends in USGS streamgaging<tspan
           x="0"
-          y="15"
+          y="10"
         >1890 - present</tspan></text>
         <text
           id="annotate-svg"
@@ -2003,13 +2003,17 @@ $polygon: '~@/assets/images/polygon.png';
     width: 20px;
     display: inline-block;
 }
+#georgiaSlider  {
+  margin-top: 50px;
+}
 #cartogram-svg {
   width:150%;
   height: auto;
 
   #title-svg {
-    color: $darkGray;
-    font-weight: bold;
+    fill: rgb(139, 139, 139);
+    font-style: italic;
+    font-size: 10px;
   }
 
 .state-label{
@@ -2039,7 +2043,7 @@ $polygon: '~@/assets/images/polygon.png';
     stroke: $lightGray;
     stroke-linecap: round;
     stroke-linejoin: round;
-    stroke-width: 1px;
+    stroke-width: 2px;
 }
 }
 .hidden {


### PR DESCRIPTION
Minor changes to the infographic to make slightly more compact and reduce whitespace at bottom: 
![image](https://user-images.githubusercontent.com/17803537/90290285-35805780-de43-11ea-8b37-b1cd70ea6774.png)

And for the cartogram, swapped the text styling of the title to be the same as the other annotation in the R script, as well as adjusted the spacing between the following paragraph, cartogram, and slider to be the same: 
![image](https://user-images.githubusercontent.com/17803537/90290387-68c2e680-de43-11ea-958c-647185ce0072.png)
