### PR TITLE
"Final" text edits

### DIFF
--- a/src/assets/annotatedTimeline/annotatedTimeline.js
+++ b/src/assets/annotatedTimeline/annotatedTimeline.js
@@ -2,7 +2,7 @@ export default {
     textContents: {
         title: "A Brief History of USGS Streamgaging ",
         introText: "",
-        firstParagraphText: '<br>USGS streamgaging began in 1889 with the establishment of the first gage on the Rio Grande in Embudo, New Mexico, where the first team of hydrographers were being trained in new techniques to <a href="https://pubs.usgs.gov/fs/2014/3034/pdf/fs2014-3034.pdf" target="_blank">measure water flow systematically</a>. Today, the USGS streamgaging network extends across all 50 states and Puerto Rico to provide real-time data delivery, putting the Nation at the forefront of water monitoring in the 21st century. <br><br><span class="caption">Click to expand the eras in the timeline below to learn more.</span>',
+        firstParagraphText: '<br>USGS streamgaging began in 1889 with the establishment of the first streamgage on the Rio Grande in Embudo, New Mexico, where the first team of hydrographers were being trained in new techniques to <a href="https://pubs.usgs.gov/fs/2014/3034/pdf/fs2014-3034.pdf" target="_blank">measure water flow systematically</a>. Today, the USGS streamgaging network extends across all 50 states and Puerto Rico to provide real-time data delivery, putting the Nation at the forefront of water monitoring in the 21st century. <br><br><span class="caption">Click to expand the eras in the timeline below to learn more.</span>',
 
     }
 };

--- a/src/assets/annotatedTimeline/newTimeline.js
+++ b/src/assets/annotatedTimeline/newTimeline.js
@@ -3,13 +3,13 @@ export default{
         methods:[
             {
                 'title': 'Characterizing flow for irrigation & hydropower',
-                'method': 'USGS streamgaging began in 1889 with the establishment of the first gage (see ' +
+                'method': 'USGS streamgaging began in 1889 with the establishment of the first streamgage (see ' +
                         '<a href="https://www.usgs.gov/faqs/why-does-usgs-use-spelling-gage-instead-gauge" target="_blank">'+
                         'why the USGS spelling is “gage” instead of “gauge”</a>) on the Rio Grande in Embudo, New Mexico, where hydrographers were ' +
                         'trained in new techniques to measure river flow. The earliest era of streamgaging helped assess the ' +
                         'potential of the Nation’s water resources to support growth in the western U.S by monitoring the ' +
                         'amount of water for hydropower and irrigation. The resulting slow accumulation of monitoring locations ' +
-                        'resulted in nearly 200 active gages by the turn of the century.',
+                        'resulted in nearly 200 active streamgages by the turn of the century.',
                 'timePeriod': '1889 - 1930'
             },
             {
@@ -30,7 +30,7 @@ export default{
                         'surface mining on streams) grew or declined, leading to variations in the national streamgage count. The ' +
                         'number of streamgages declined from 1991-1996 due to stringent national budget cuts and other ' +
                         'factors, but Congress established funding to retain Federal Priority Streamgages in 2004. The need for ' +
-                        'advanced flood warning has driven much of the growth in the national gage count during recent years.',
+                        'advanced flood warning has driven much of the growth in the national streamgage count during recent years.',
                 'timePeriod': '1966 - Present'
             }
         ]

--- a/src/assets/gagesBarChartAnimation/gagesBarChartAnimationText.js
+++ b/src/assets/gagesBarChartAnimation/gagesBarChartAnimationText.js
@@ -2,7 +2,7 @@ export default {
     textContents: {
         title1: "Gages Through",
         title2: "the Ages",
-        introText: "The history of streamgages reflects",
+        introText: "How the history of streamgaging reflects",
         introText2: "the evolving water needs of the nation",
         graphTitle: "",
         caption:"U.S. Geological Survey’s active streamgages since 1889 until present day",

--- a/src/assets/mapboxSlider/atlantaSliderText.js
+++ b/src/assets/mapboxSlider/atlantaSliderText.js
@@ -2,11 +2,11 @@ export default {
     textContents: {
         title: "National Water Monitoring Builds on a Mosaic of Local Water Priorities ",
         introText: "",
-        caption: 'A slider map depicting the change in <span class="legendDot urbanGage"></span> urban and <span class="legendDot ruralGage"></span> non-urban stream gages and the growth of <span class="urbanPolygon"/></span> urban extent between 1967 and 2018 in north central Georgia.',
+        caption: 'A slider map depicting the change in <span class="legendDot urbanGage"></span> urban and <span class="legendDot ruralGage"></span> non-urban streamgages and the growth of <span class="urbanPolygon"/></span> urban extent between 1967 and 2018 in north central Georgia.',
         paragraphSections: [
-            {aboveMapText: "The evolving local, regional, and national water monitoring priorities have steered growth and retirement of gages through time. Early USGS streamgages were distributed widely across the landscape, while newer gages have been placed strategically to meet the needs of the era. State-level patterns in gages are the unique fingerprints of changing water priorities."
+            {aboveMapText: "The evolving local, regional, and national water monitoring priorities have steered growth and retirement of streamgages through time. Early USGS streamgages were distributed widely across the landscape, while newer streamgages have been placed strategically to meet the needs of the era. State-level patterns in streamgages are the unique fingerprints of changing water priorities."
             },
-            {aboveSliderText: "An example of evolving water-data needs is in the metro area of Atlanta, Georgia, where population increased five-fold between 1967 and 2018, major increases in urban gages (see blue dots in the map below) were motivated by the need to better plan for floods and droughts—as well as new regulatory demands and the complex litigation of water uses between Atlanta and downstream communities."}
+            {aboveSliderText: "An example of evolving water-data needs is in the metro area of Atlanta, Georgia, where population increased five-fold between 1967 and 2018, major increases in urban streamgages (see blue dots in the map below) were motivated by the need to better plan for floods and droughts—as well as new regulatory demands and the complex litigation of water uses between Atlanta and downstream communities."}
         ]
     }
 };

--- a/src/assets/methods/methods.js
+++ b/src/assets/methods/methods.js
@@ -15,18 +15,18 @@ export default{
                         'original PDF. <br><br><sup>*</sup><i>Any use of trade, firm, or product names is for descriptive purposes only and does not imply endorsement by the U.S. Government</i>'
             },
             {
-                'title': 'Calculating USGS stream gages',
-                'method': 'To calculate the annual number of active USGS stream gages, an inventory of the USGS National Water Information System was completed using an <a href="https://github.com/USGS-R/national-flow-observations" target="_blank">R-based reproducible data pipeline called national-flow-observations</a>. For the purposes of this visualization, "active" gages are considered those with at least 335 days of data every year. Early gages with only monthly records were counted as active.'
+                'title': 'Calculating USGS streamgages',
+                'method': 'To calculate the annual number of active USGS streamgages, an inventory of the USGS National Water Information System was completed using an <a href="https://github.com/USGS-R/national-flow-observations" target="_blank">R-based reproducible data pipeline called national-flow-observations</a>. For the purposes of this visualization, "active" streamgages are considered those with at least 335 days of data every year. Early streamgages with only monthly records were counted as active.'
             },
             {
-                'title': 'Determining if a gage is urban or non-urban',
-                'method': 'To determine whether a stream gage is in an urban or rural area, we used urban extent spatial ' +
+                'title': 'Determining if a streamgage is urban or non-urban',
+                'method': 'To determine whether a streamgage is in an urban or rural area, we used urban extent spatial ' +
                         'data from the U.S. Census Bureau for years closest to our years of interest (1967 and 2018). ' +
                         'For the spatial extents used in the 1967 visual, we digitized maps from the <a href="https://www2.census.gov/library/publications/decennial/1970/pc-s1-supplementary-reports/pc-s1-108ch2.pdf" target="_blank">' +
                         '1970 US Census Bureau report on urbanized areas in the United States</a>. For the spatial extents ' +
                         'used in the 2018 visual, we used <a href="https://www.census.gov/geographies/mapping-files/time-series/geo/carto-boundary-file.html" target="_blank">cartographic boundary files for 2018 urban areas from the ' +
-                        'U.S. Census Bureau</a>. Using the urban extent spatial data and the USGS stream gage location ' +
-                        'data, we used point-in-polygon methods in R to determine if a stream gage was inside or ' +
+                        'U.S. Census Bureau</a>. Using the urban extent spatial data and the USGS streamgage location ' +
+                        'data, we used point-in-polygon methods in R to determine if a streamgage was inside or ' +
                         'outside of an urbanized area. Those methods can be found in <a href="https://github.com/usgs-makerspace/gages-through-the-ages/tree/master/data_processing_pipeline">this data processing pipeline</a>.'
             }
         ]


### PR DESCRIPTION
Creating consistency with how we use `gage` and `streamgage`. Also, eliminate instances of `stream gage` and make them one word. Reason for why some were changed and why some were not:

> adopt "streamgage" and "streamgaging" everywhere accept for on the visuals themselves - so the name, the top map/bars, the infographic, the annotated bar chart, and the cartogram can go on with using "gage" because our visuals need to optimize the use of space and "gage" is shorter. I do think that the infographic introducing each dot as a "streamgage" and then the very next sentence saying "active gages" is OK because that clearly sets up the link between those two terms having the same meaning. Unmerged commit with my suggested changes

Second thing is a suggested edit to the subtitle to make it sound more subtitle-y