### PR TITLE
Possible fix for line height differences: move both lines of title into one <h1> tag

### DIFF
--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -8,11 +8,17 @@
       class="container"
     >
       <h1 class="main-title">
-        <span class="lowlight" style="line-height: 20%">
+        <span
+          class="lowlight"
+          style="line-height: 20%"
+        >
           {{ text.title1 }}
         </span>
         <br>
-        <span class="lowlight" style="line-height: 20%">
+        <span
+          class="lowlight"
+          style="line-height: 20%"
+        >
           {{ text.title2 }}
         </span>
       </h1>

--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -11,9 +11,8 @@
         <span class="lowlight" style="line-height: 20%">
           {{ text.title1 }}
         </span>
-      </h1>
-      <h1 class="main-title">
-        <span class="lowlight">
+        <br>
+        <span class="lowlight" style="line-height: 20%">
           {{ text.title2 }}
         </span>
       </h1>


### PR DESCRIPTION
I remember seeing this and thinking about how we have those two title lines in two different `<h1>` elements. The problem is that they may look too squished now, but the spacing is consistent. Happy to let someone else try this and have this PR closed but thought I'd spend 10 minutes and give it a whirl. Issue described in https://github.com/usgs-makerspace/makerspace-sandbox/issues/608

On desktop now:

![image](https://user-images.githubusercontent.com/13220910/90403606-d9961880-e066-11ea-8544-b7a5e8d236f9.png)

On mobile now:

![image](https://user-images.githubusercontent.com/13220910/90403655-e6b30780-e066-11ea-909f-284ec2051f07.png)

