### PR TITLE
Add new pre-footer code and components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Added]
+## [2.1.1] - 2026-03-09
+- New pre-footer code links component 
+
 ## [Released]
 ## [2.1.0] - 2026-03-01
 - Domain migrated to water.usgs.gov/vizlab/gages-through-the-ages 

--- a/package-lock.json
+++ b/package-lock.json
@@ -739,6 +739,7 @@
       "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -1510,16 +1511,6 @@
         "win32"
       ]
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1816,6 +1807,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2325,6 +2317,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2652,6 +2645,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -3335,6 +3329,7 @@
       "integrity": "sha512-uf6HoO8fy6ClsrShvMgaKUn14f2EHQLQRtpsZZLeU/Mv0Q1K5P0+x2uvH6Cub39TVVbWNSrraUhDAoFph6vh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -3364,6 +3359,16 @@
       ],
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/semver": {
@@ -3438,19 +3443,19 @@
       }
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo"
@@ -3535,6 +3540,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3635,6 +3641,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.29.tgz",
       "integrity": "sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.29",
         "@vue/compiler-sfc": "3.5.29",

--- a/src/App.vue
+++ b/src/App.vue
@@ -91,7 +91,7 @@
       padding-top: 1.1rem;
       font-weight: 700;
       @media screen and (max-width: 600px) {
-        font-size: .8em;
+        font-size: 1.35em;
     }
     }
     caption,p{
@@ -126,7 +126,12 @@
     font-size:16pt;
     line-height:1.5em;
   }
-
+  figcaption {
+    font-size: 1.6rem;
+    font-style: italic;
+    text-align: start;
+    padding: 1rem 0.5rem;
+  }
   a{
     text-decoration:none;
     cursor:pointer;

--- a/src/App.vue
+++ b/src/App.vue
@@ -81,14 +81,14 @@
       margin: 20px 0;
     }
     h2{
-      font-size: 2em;
+      font-size: 3.2rem;
       margin-top: 80px;
       font-weight: 700;
-  
+      padding: 0;
     }
     h3{
-      font-size: 1.4em;
-      padding-top: .5em;
+      font-size: 2.37rem;
+      padding-top: 1.1rem;
       font-weight: 700;
       @media screen and (max-width: 600px) {
         font-size: .8em;

--- a/src/App.vue
+++ b/src/App.vue
@@ -91,7 +91,7 @@
       padding-top: 1.1rem;
       font-weight: 700;
       @media screen and (max-width: 600px) {
-        font-size: 1.35em;
+        font-size: 1.53rem;
     }
     }
     caption,p{

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -18,8 +18,8 @@
 
   font-size: 62.5%;
 
-  --title-font: Roboto Slab;
-  --default-font: Source Sans Pro;
+  /* --title-font: Roboto Slab;
+  --default-font: Source Sans Pro; */
 }
 
 /* Declare color variables */

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -1,0 +1,125 @@
+@import url('https://fonts.googleapis.com/css2?family=Assistant:wght@200;300;400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Abel&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');
+
+/* semantic color variables for this project */
+/* Define colors */
+:root {
+  --white: #ffffff;
+  --white-soft: #F0F0F0;
+
+  --black-soft: #151515;
+  --dodger-blue: #1e90ff;
+  --medium-grey: #B5B5B5;
+  --medium-purple: #8F00DB;
+  --medium-blue: #4365A8;
+  --medium-orange: #E48951;
+  --usgs-blue: #00264c;
+  --usgs-green: #006F41;
+
+  font-size: 62.5%;
+
+  --title-font: Abel;
+  --style-font: Assistant;
+  --default-font: Source Sans Pro;
+}
+
+/* Declare color variables */
+:root {
+  --color-background: var(--white);
+  --color-text: var(--black-soft);
+  --color-title-text: var(--dodger-blue);
+  --color-overlay: var(--black-soft);
+  --color-overlay-text: var(--white-soft);
+  --color-code-links-background: var(--medium-grey);
+  --color-link: var(--medium-purple);
+  --color-bar-focal: var(--medium-blue);
+  --color-bar-default: var(--medium-grey);
+  --color-map-focal: var(--medium-orange);
+  --color-map-default: var(--white);
+  --color-USGS-header-footer: var(--usgs-blue);
+  --color-prefooter-highlight: var(--medium-blue);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  /* font-weight: normal; */
+}
+
+body {
+  min-height: 100vh;
+  color: var(--color-text);
+  fill: var(--color-text); /* Needed for text added w/ d3 */
+  background: var(--color-background);
+  transition:
+    color 0.5s,
+    background-color 0.5s;
+  line-height: 1.2;
+  font-family: sans-serif; /* This is fallback font for old browsers */
+  font-family: var(--default-font);
+  font-weight: 400;
+  font-size: 2rem;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overscroll-behavior: none;
+  @media screen and (max-width: 600px) {
+    font-size: 16px;
+  }
+}
+
+
+h1 {
+  font-size: 3.5rem;
+  font-weight: 300;
+  font-family: var(--title-font);
+  line-height: 1;
+  text-align: left;
+  padding: 0rem 0 1rem 0;
+  text-shadow: 1px 1px 100px rgba(0,0,0,.8);
+  @media screen and (max-width: 600px) {
+    font-size: 2.5em;
+  }
+}
+h2 {
+  font-size: 1.3rem;
+  font-weight: 300;
+  text-align: left;
+  font-family: var(--style-font);
+  margin-top: 5px;
+  line-height: 1.2;
+  padding: 3rem 0 1rem 0;
+  @media screen and (max-width: 600px) {
+    font-size: 2em;
+  }
+}
+h3{
+  font-size: 1.3em;
+  font-family: var(--style-font);
+  font-weight: 400;
+  @media screen and (max-height: 770px) {
+    font-size: 1.2em;
+  }
+  @media screen and (max-width: 700px) {
+      font-size: 0.9em;
+  } 
+  @media screen and (max-height: 500px) {
+      font-size: 0.9em;
+  } 
+}
+p, text {
+  font-family: var(--style-font);
+  font-size: 1em;
+  @media screen and (max-width: 700px) {
+      font-size: 0.9em;
+  } 
+  @media screen and (max-height: 500px) {
+      font-size: 0.9em;
+  } 
+}
+a { 
+  color: black;
+}

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -1,6 +1,5 @@
-@import url('https://fonts.googleapis.com/css2?family=Assistant:wght@200;300;400;500;600;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Abel&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@200;300;400;500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@100..900&display=swap');
 
 /* semantic color variables for this project */
 /* Define colors */
@@ -19,8 +18,7 @@
 
   font-size: 62.5%;
 
-  --title-font: Abel;
-  --style-font: Assistant;
+  --title-font: Roboto Slab;
   --default-font: Source Sans Pro;
 }
 
@@ -41,6 +39,13 @@
   --color-prefooter-highlight: var(--medium-blue);
 }
 
+/* @media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: var(--black-soft);
+    --color-text: var(--white-soft);
+  }
+} */
+
 *,
 *::before,
 *::after {
@@ -60,66 +65,22 @@ body {
   line-height: 1.2;
   font-family: sans-serif; /* This is fallback font for old browsers */
   font-family: var(--default-font);
-  font-weight: 400;
   font-size: 2rem;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overscroll-behavior: none;
-  @media screen and (max-width: 600px) {
-    font-size: 16px;
-  }
 }
-
-
 h1 {
-  font-size: 3.5rem;
-  font-weight: 300;
-  font-family: var(--title-font);
-  line-height: 1;
-  text-align: left;
+  font-size: 5rem;
+  font-weight: 800;
   padding: 0rem 0 1rem 0;
-  text-shadow: 1px 1px 100px rgba(0,0,0,.8);
-  @media screen and (max-width: 600px) {
-    font-size: 2.5em;
-  }
 }
 h2 {
-  font-size: 1.3rem;
-  font-weight: 300;
-  text-align: left;
-  font-family: var(--style-font);
-  margin-top: 5px;
-  line-height: 1.2;
+  font-size: 2.5rem;
+  font-weight: 700;
   padding: 3rem 0 1rem 0;
-  @media screen and (max-width: 600px) {
-    font-size: 2em;
-  }
 }
-h3{
-  font-size: 1.3em;
-  font-family: var(--style-font);
-  font-weight: 400;
-  @media screen and (max-height: 770px) {
-    font-size: 1.2em;
-  }
-  @media screen and (max-width: 700px) {
-      font-size: 0.9em;
-  } 
-  @media screen and (max-height: 500px) {
-      font-size: 0.9em;
-  } 
-}
-p, text {
-  font-family: var(--style-font);
-  font-size: 1em;
-  @media screen and (max-width: 700px) {
-      font-size: 0.9em;
-  } 
-  @media screen and (max-height: 500px) {
-      font-size: 0.9em;
-  } 
-}
-a { 
-  color: black;
+p, text, li {
+  padding: 0 0 1rem 0;
 }

--- a/src/assets/css/base.css
+++ b/src/assets/css/base.css
@@ -74,7 +74,6 @@ body {
 h1 {
   font-size: 5rem;
   font-weight: 800;
-  padding: 0rem 0 1rem 0;
 }
 h2 {
   font-size: 2.5rem;

--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -13,9 +13,11 @@ footer, #navbar {
     box-sizing: border-box;
 }	
 
-footer, header, main, nav, div {
+/* Commented out so that it doesn't affect USWDS banner css */
+/* Moved into HeaderUSGS.vue and FooterUSGS.vue */
+/* footer, header, main, nav, div {
     display: block;
-}
+} */
 
 .tmp-container {
 	margin-right: auto;
@@ -137,6 +139,7 @@ footer.footer .footer-doi ul.menu li a {
     cursor: pointer;
 }
 
+
 footer.footer .footer-doi ul.menu li:first-of-type {
     padding-left: 0px;
 }
@@ -206,9 +209,6 @@ footer.footer .footer-social-links ul li:last-of-type {
 footer.footer .footer-social-links ul li a i {
 	color:#fff;
 	font-size: 24px;
-}
-figcaption {
-    font-style: italic;
 }
 
 /* COMMENTED OUT B/C IMPORTING USING vue-fontawesome PACKAGE INSTEAD */ 

--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -133,6 +133,8 @@ footer.footer .footer-doi ul.menu li a {
     color: #ffffff;
     float: left;
     font-size: 12px;
+    text-decoration: none;
+    cursor: pointer;
 }
 
 footer.footer .footer-doi ul.menu li:first-of-type {
@@ -162,6 +164,15 @@ footer.footer .footer-wrap .menu.nav a {
 	padding: 4px 0px;
 	color: #ffffff;
 	font-size: 12px;
+	text-decoration: none;
+	cursor: pointer;
+}
+
+footer.footer .footer-doi ul.menu li a:hover,
+footer.footer .footer-doi ul.menu li a:focus-visible,
+footer.footer .footer-wrap .menu.nav a:hover,
+footer.footer .footer-wrap .menu.nav a:focus-visible {
+	text-decoration: underline;
 }
 
 footer.footer .footer-social-links {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,5 +1,37 @@
+@import './base.css';
 @import './common.css'; /* USGS Viz ID Stylesheet */
 @import './custom.css'; /* USGS Viz ID Stylesheet */
 
+/* whole page except header fit within viewport - no scrolling */
+#app {
+  /* height: calc(100vh + 87px); 87 is the height of the USGS header */
+  margin: 0 auto;
+}
+
 /* css styles specific to page content exclusive of header and footer*/
 /* NOT component-specific */
+#visualization-container {
+  margin: 5rem 0 5rem 0;
+}
+.title {
+  font-family: sans-serif; /* This is fallback font for old browsers */
+  font-family: var(--title-font);
+  color: var(--color-title-text);
+}
+/* set color of links throughout */
+a {
+  color: var(--color-link);
+}
+/* sets width of text column throughout components */
+.text-container {
+  max-width: 70rem; /* 70 pixels on desktop */
+  margin: 0 auto 0 auto;
+}
+.text-container.mobile {
+  max-width: 90vw; /* 90% of view width on mobile */
+}
+/* sets max-width of figure elements throughout components */
+.figure-container {
+  max-width: 80vw;
+  margin: 0 auto 0 auto;
+}

--- a/src/components/FooterUSGS.vue
+++ b/src/components/FooterUSGS.vue
@@ -24,7 +24,6 @@
           <li class="first leaf menu-links menu-level-1"><a href="https://www.doi.gov/" target="_blank">U.S. Department of the Interior</a></li>
           <li class="leaf menu-links menu-level-1"><a href="https://www.doioig.gov/" target="_blank">DOI Inspector General</a></li>
           <li class="leaf menu-links menu-level-1"><a href="https://www.whitehouse.gov/" target="_blank">White House</a></li>
-          <li class="leaf menu-links menu-level-1"><a href="https://www.whitehouse.gov/omb/management/egov/" target="_blank">E-gov</a></li>
           <li class="leaf menu-links menu-level-1"><a href="https://www.doi.gov/pmb/eeo/no-fear-act" target="_blank">No Fear Act</a></li>
           <li class="last leaf menu-links menu-level-1"><a href="https://www.usgs.gov/foia" target="_blank">FOIA</a></li>
         </ul>
@@ -35,7 +34,7 @@
         <ul class="social">
           <li class="follow">Follow</li>
           <li class="twitter">
-            <a href="https://twitter.com/usgs_datasci" target="_blank" aria-label="twitter link">
+            <a href="https://x.com/usgs_water" target="_blank" aria-label="twitter link">
               <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'square-x-twitter' } " class="fa fa-square-x-twitter"><span class="only">Twitter</span></font-awesome-icon>
             </a>
           </li>

--- a/src/components/GagesBarChartAnimation.vue
+++ b/src/components/GagesBarChartAnimation.vue
@@ -5538,21 +5538,21 @@ $brightYellow: rgb(255,200,51);
   }
   .main-title{
     text-align: center;
-    font-size: 4em;
+    font-size: 6.4rem;
     font-weight: 900;
     line-height: 115%;
 
 
     @media screen and (max-width: 600px) {
-      font-size: 3em;
+      font-size: 4.8rem;
     }
    
   }
   .subtitle {
     text-align: center;
-    margin-top: 2em;
+    margin-top: 3.2rem;
     @media screen and (max-width: 600px) {
-      font-size: 1.2em;
+      font-size: 1.92rem;
     }
 
   }

--- a/src/components/MapImageSlider.vue
+++ b/src/components/MapImageSlider.vue
@@ -2136,7 +2136,10 @@ $polygon: '@/assets/images/polygon.png';
   fill: white;
   text-anchor: middle;
 }
-
+.mapcaption {
+  font-size: 1.6rem;
+  font-style: italic;
+}
 @media screen and (min-width: 600px){
     .beer-slider[data-beer-label]:after,
     .beer-reveal[data-beer-label]:after{

--- a/src/components/MethodsSection.vue
+++ b/src/components/MethodsSection.vue
@@ -64,8 +64,8 @@
     background-size: 15px 10px;
     background-color: $brightBlue;
     color: white;
-    font-size: 2rem;
-
+    font-size: 2.37rem;
+    padding: 1.6rem 5.6rem 1.6rem 2rem;
   }
   .usa-accordion__button[aria-expanded=false]{
     background-image: url($chevronLeft);

--- a/src/components/MethodsSection.vue
+++ b/src/components/MethodsSection.vue
@@ -66,6 +66,9 @@
     color: white;
     font-size: 2.37rem;
     padding: 1.6rem 5.6rem 1.6rem 2rem;
+    @media screen and (max-width: 600px) {
+        font-size: 2rem;
+    }
   }
   .usa-accordion__button[aria-expanded=false]{
     background-image: url($chevronLeft);

--- a/src/components/MethodsSection.vue
+++ b/src/components/MethodsSection.vue
@@ -64,6 +64,8 @@
     background-size: 15px 10px;
     background-color: $brightBlue;
     color: white;
+    font-size: 2rem;
+
   }
   .usa-accordion__button[aria-expanded=false]{
     background-image: url($chevronLeft);

--- a/src/components/NewTimeline.vue
+++ b/src/components/NewTimeline.vue
@@ -302,6 +302,7 @@ $brightYellow: rgb(255,200,51);
     min-height: 5.5em;
     color: white;
     text-align: center;
+    font-size: 1.75rem;
   }
   .usa-accordion__button[aria-expanded=false] {
     background-image: url($chevronLeft);
@@ -332,6 +333,7 @@ $brightYellow: rgb(255,200,51);
     font-size:8px;
     font-weight: 800;
 }
+
 .highlight {
   fill: $brightBlue;
     stroke-miterlimit:10; 

--- a/src/components/NewTimeline.vue
+++ b/src/components/NewTimeline.vue
@@ -314,6 +314,9 @@ $brightYellow: rgb(255,200,51);
   .content {
     grid-column: 1 / 4;
   }
+  .usa-accordion__content {
+    padding: 1.6rem 2rem;
+}
   .usa-accordion__content[hidden] {
     display: none !important;
   }

--- a/src/components/NewTimeline.vue
+++ b/src/components/NewTimeline.vue
@@ -303,6 +303,7 @@ $brightYellow: rgb(255,200,51);
     color: white;
     text-align: center;
     font-size: 1.75rem;
+    padding: 1.6rem 5.6rem 1.6rem 2rem;
   }
   .usa-accordion__button[aria-expanded=false] {
     background-image: url($chevronLeft);

--- a/src/components/PreFooterCodeLinks.vue
+++ b/src/components/PreFooterCodeLinks.vue
@@ -42,12 +42,11 @@
   font-family: 'Noto Sans', sans-serif;
   font-size: 1.5rem;
   color: #1e1e1e;
-  width: 100%; // make full width to match page appearance
 
   &__divider {
     border-top: 1px solid #d4d8dd;
     margin: 0 auto 1.5rem;
-    width: 100%; // addded for full width
+    width: min(90%, 800px);
   }
 
   &__content {
@@ -55,9 +54,8 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.75rem;
-    width: min(90%, 700px);
+    width: min(90%, 800px);
     margin: 0 auto;
-    width: 100%; // added for full width
   }
 
   &__item {

--- a/src/components/PreFooterCodeLinks.vue
+++ b/src/components/PreFooterCodeLinks.vue
@@ -1,35 +1,94 @@
 <template>
-  <div id="code-repository-link-container">
-    <a
-      :href=gitHubRepositoryLink
-      target="_blank"
-      aria-label="github link"
-    >See the code behind this visualization
-      <font-awesome-icon :icon="{ prefix: 'fab', iconName: 'github' }" />
-    </a>
+  <div class="pre-footer-links">
+    <div class="pre-footer-links__divider" />
+    <div class="pre-footer-links__content">
+      <a
+        class="pre-footer-links__item"
+        href="https://water.usgs.gov/vizlab/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        See more <span v-if="!mobileView">visualizations</span> from the USGS Vizlab
+      </a>
+      <a
+        class="pre-footer-links__item"
+        :href="gitHubRepositoryLink"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Get the code behind this page
+        <font-awesome-icon
+          :icon="{ prefix: 'fab', iconName: 'github' }"
+          aria-hidden="true"
+        />
+      </a>
+    </div>
   </div>
 </template>
 
 <script setup>
+  import { isMobileOnly } from 'mobile-device-detect';
+
+  // global variables
+  const mobileView = isMobileOnly;
+
   const gitHubRepositoryLink = import.meta.env.VITE_APP_GITHUB_REPOSITORY_LINK;
 </script>
 
 <style scoped lang="scss">
+.pre-footer-links {
+  background-color: white;
+  padding: 1.5rem 1rem 2rem;
+  font-family: 'Noto Sans', sans-serif;
+  font-size: 1.5rem;
+  color: #1e1e1e;
+  width: 100%; // make full width to match page appearance
 
-  #code-repository-link-container {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-    background-color: #B5B5B5;
-    margin: 0 auto;
-    padding: 4px 15px;
-    a {
-      color: #151515;
-      font-size: 16pt;
-      font-weight: 400;
-      margin-left: 10px;
-      text-decoration: none;
-    }
+  &__divider {
+    border-top: 1px solid #d4d8dd;
+    margin: 0 auto 1.5rem;
+    width: 100%; // addded for full width
   }
 
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    width: min(90%, 700px);
+    margin: 0 auto;
+    width: 100%; // added for full width
+  }
+
+  &__item {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background-image: linear-gradient(var(--color-prefooter-highlight), var(--color-prefooter-highlight));
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 0.2rem;
+    padding-bottom: 0.1rem;
+    transition: color 0.2s ease-in-out;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--color-prefooter-highlight);
+    }
+  }
+}
+
+@media (min-width: 640px) {
+  .pre-footer-links {
+    &__content {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+}
 </style>

--- a/src/views/VisualizationView.vue
+++ b/src/views/VisualizationView.vue
@@ -60,7 +60,7 @@
         font-size: 1.15rem;
       }
       caption,p{
-        font-size: 1rem;
+        font-size: 1.6rem;
       }
     }
   }


### PR DESCRIPTION
Similar to this [water-cycle MR](https://github.com/DOI-USGS/water-cycle/pull/26), this implements the new pre-footer code and portfolio link component. Changes made:

- I had to add `base.css` file
- new component added `PreFooterCodeLinks.vue`
- CSS in `PreFooterCodeLinks.vue` modified to use `width: 100%` for the `.pre-footer-links`, `&__divider`, and `&__content` elements so the footer extends the full width of the page.
- Added `--color-prefooter-highlight: var(--medium-blue);` to `base.css` to style active links. 

To review, pull down changes, Run `npm i` to install dependencies. Then run `npm run dev` to build locally. Expected output:

<img width="1462" height="537" alt="Screenshot 2026-03-09 at 11 38 32 AM" src="https://github.com/user-attachments/assets/3313602b-f4a6-48ca-94d5-6d9964d67762" />

@cnell-usgs is this approach correct? I noticed the blue active links highlight isn't working. 